### PR TITLE
Change the default wallet rpc listen port to 22026

### DIFF
--- a/src-electron/main-process/modules/backend.js
+++ b/src-electron/main-process/modules/backend.js
@@ -107,7 +107,7 @@ export class Backend {
         net_type: "mainnet"
       },
       wallet: {
-        rpc_bind_port: 18082,
+        rpc_bind_port: 22026,
         log_level: 0
       }
     };


### PR DESCRIPTION
18082 will conflict with a running monerod on the system (18082 is monero's default ZMQ RPC port).

This moves the default to 22026, which is clustered with oxend's other ports (22022 P2P, 22023 RPC, 22025 OMQ).

(The '24 hole there was once used for the Monero ZMQ RPC interface in oxend, but we no longer have that--but if we *do* need another port for something 22024 will likely be it, so 22026 should be safe from future oxend requirements).