### PR TITLE
Fix staking for reserved contribution spots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "loki-electron-wallet",
-  "version": "1.5.4",
+  "name": "oxen-electron-wallet",
+  "version": "1.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxen-electron-wallet",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Modern GUI interface for Oxen Currency",
   "productName": "Oxen Electron Wallet",
   "repository": {

--- a/src/components/service_node/service_node_list.vue
+++ b/src/components/service_node/service_node_list.vue
@@ -30,9 +30,9 @@
             </span>
             <span v-if="node.awaitingContribution" class="contrib-amounts">
               {{ $t("strings.serviceNodeDetails.minContribution") }}:
-              {{ getMinContribution(node) }} OXEN •
+              {{ getMinContribution(node, our_address) }} OXEN •
               {{ $t("strings.serviceNodeDetails.maxContribution") }}:
-              {{ openForContriubtionOxen(node) }} OXEN
+              {{ openForContributionOxen(node, our_address) }} OXEN
             </span>
           </q-item-label>
         </q-item-section>
@@ -118,7 +118,7 @@ export default {
     nodeWithMinContribution(node) {
       const nodeWithMinContribution = {
         ...node,
-        minContribution: this.getMinContribution(node)
+        minContribution: this.getMinContribution(node, this.our_address)
       };
       return nodeWithMinContribution;
     },

--- a/src/components/service_node/service_node_staking.vue
+++ b/src/components/service_node/service_node_staking.vue
@@ -151,17 +151,24 @@ export default {
     },
     awaiting_service_nodes(state) {
       const nodes = state.gateway.daemon.service_nodes.nodes;
-      // a reserved node is one on which someone is a "contributor" of amount = 0
       const getOurContribution = node =>
         node.contributors.find(
-          c => c.address === this.our_address && c.amount > 0
+          c => c.address === this.award_address && c.amount > 0
+        );
+      // a reserved node is one on which someone is a "contributor" of amount = 0
+      const reservedForUs = node =>
+        node.contributors.find(
+          c => c.address === this.award_address && c.amount == 0
         );
       const isAwaitingContribution = node =>
-        !node.active && !node.funded && node.requested_unlock_height === 0;
+        !node.active && !node.funded;
       const isAwaitingContributionNonReserved = node =>
-        isAwaitingContribution(node) && !getOurContribution(node);
+        node.requested_unlock_height === 0 &&
+        isAwaitingContribution(node) &&
+        !getOurContribution(node) &&
+        this.openForContribution(node) > 0;
       const isAwaitingContributionReserved = node =>
-        isAwaitingContribution(node) && getOurContribution(node);
+        isAwaitingContribution(node) && reservedForUs(node);
 
       // we want the reserved nodes sorted by fee at the top
       const awaitingContributionNodesReserved = nodes

--- a/src/components/service_node/service_node_staking.vue
+++ b/src/components/service_node/service_node_staking.vue
@@ -289,11 +289,11 @@ export default {
     },
     minStake() {
       const node = this.getNodeWithPubKey();
-      return this.getMinContribution(node);
+      return this.getMinContribution(node, this.award_address);
     },
     maxStake() {
       const node = this.getNodeWithPubKey();
-      return this.openForContriubtionOxen(node);
+      return this.openForContributionOxen(node, this.award_address);
     },
     getFeeDecimal(node) {
       const operatorPortion = node.portions_for_operator;

--- a/src/mixins/service_node_mixin.js
+++ b/src/mixins/service_node_mixin.js
@@ -1,27 +1,43 @@
 export default {
   methods: {
-    getMinContribution(node) {
+    // Returns the atomic, unfilled, reserved contributions for the given wallet
+    getUnfilledReservedContribution(node, addr) {
+      for (const contributor of node.contributors)
+        if (contributor.address === addr && contributor.amount === 0 && contributor.reserved > 0)
+          return contributor.reserved;
+      return 0;
+    },
+    getMinContribution(node, myaddr) {
+      if (node.funded)
+        return 0;
+
       const MAX_NUMBER_OF_CONTRIBUTORS = 4;
-      // This is calculated in the same way it is calculated on the LokiBlocks site
-      const openContributionRemaining = this.openForContribution(node);
-      const minContributionAtomicUnits =
-        !node.funded && node.contributors.length < MAX_NUMBER_OF_CONTRIBUTORS
-          ? openContributionRemaining /
-            (MAX_NUMBER_OF_CONTRIBUTORS - node.contributors.length)
-          : 0;
+      // If we have a reserved spot then that is our minimum:
+      let minContributionAtomicUnits = this.getUnfilledReservedContribution(node, myaddr);
+      // Otherwise we can contribute our fair share of whatever amount is left (i.e. REMAINING/N
+      // when there are N available spots).
+      if (minContributionAtomicUnits === 0 && node.contributors.length < MAX_NUMBER_OF_CONTRIBUTORS) {
+        const openContributionRemaining = this.openForContribution(node);
+
+        minContributionAtomicUnits = openContributionRemaining /
+          (MAX_NUMBER_OF_CONTRIBUTORS - node.contributors.length);
+      }
+
       const minContributionOxen = minContributionAtomicUnits / 1e9;
       // ceiling to 4 decimal places
       return minContributionOxen.toFixed(4);
     },
-    openForContribution(node) {
-      const openContributionRemaining =
+    openForContribution(node, addr = null) {
+      let openContributionRemaining =
         node.staking_requirement > node.total_reserved
           ? node.staking_requirement - node.total_reserved
           : 0;
+      if (addr)
+        openContributionRemaining += this.getUnfilledReservedContribution(node, addr);
       return openContributionRemaining;
     },
-    openForContriubtionOxen(node) {
-      return (this.openForContribution(node) / 1e9).toFixed(4);
+    openForContributionOxen(node, addr = null) {
+      return (this.openForContribution(node, addr) / 1e9).toFixed(4);
     }
   }
 };

--- a/src/mixins/service_node_mixin.js
+++ b/src/mixins/service_node_mixin.js
@@ -2,14 +2,17 @@ export default {
   methods: {
     // Returns the atomic, unfilled, reserved contributions for the given wallet
     getUnfilledReservedContribution(node, addr) {
-      for (const contributor of node.contributors)
-        if (contributor.address === addr && contributor.amount === 0 && contributor.reserved > 0)
+      for (const contributor of node.contributors) {
+        if (contributor.address === addr && contributor.amount === 0 && contributor.reserved > 0) {
           return contributor.reserved;
+        }
+      }
       return 0;
     },
     getMinContribution(node, myaddr) {
-      if (node.funded)
+      if (node.funded) {
         return 0;
+      }
 
       const MAX_NUMBER_OF_CONTRIBUTORS = 4;
       // If we have a reserved spot then that is our minimum:
@@ -32,8 +35,9 @@ export default {
         node.staking_requirement > node.total_reserved
           ? node.staking_requirement - node.total_reserved
           : 0;
-      if (addr)
+      if (addr) {
         openContributionRemaining += this.getUnfilledReservedContribution(node, addr);
+      }
       return openContributionRemaining;
     },
     openForContributionOxen(node, addr = null) {


### PR DESCRIPTION
Reserved contributions for the current wallet were not properly being
added into the available contribution room available to a wallet; this
fixes it to include any unfilled reserved spots when showing available
stakes.