### PR TITLE
Reduce ONS purchase validation buffer

### DIFF
--- a/src/components/ons/ons_input.vue
+++ b/src/components/ons/ons_input.vue
@@ -40,7 +40,7 @@ export default {
     ons_status: state => state.gateway.ons_status,
     unlocked_balance: state => state.gateway.wallet.info.unlocked_balance,
     disable_submit_button() {
-      const minBalance = this.updating ? 0.05 : 8;
+      const minBalance = this.updating ? 0.05 : 7.1;
       return this.unlocked_balance < minBalance * 1e9;
     },
     submit_label() {


### PR DESCRIPTION
The ONS purchase screen validated that the user needs 8 oxen to purchase
an ONS name. 7 oxen for the name and another single oxen to cover fees.
Given the current fee rates this buffer is too high and 0.1
oxen should be sufficient to cover a single ONS purchase.