### PR TITLE
Update oxen observer link for service nodes

### DIFF
--- a/src-electron/main-process/modules/backend.js
+++ b/src-electron/main-process/modules/backend.js
@@ -288,7 +288,7 @@ export class Backend {
         if (params.type === "tx") {
           path = "tx";
         } else if (params.type === "service_node") {
-          path = "service_node";
+          path = "sn";
         }
 
         if (path) {


### PR DESCRIPTION
Previously the oxen observer link for service nodes was of the form

https://oxen.observer/service_node/d8e...8898b6

is now

https://oxen.observer/sn/d8e...8898b6

and this updates the wallet link to reflect the change