### PR TITLE
Update algorithm counting contributors

### DIFF
--- a/src/mixins/service_node_mixin.js
+++ b/src/mixins/service_node_mixin.js
@@ -22,8 +22,13 @@ export default {
       if (minContributionAtomicUnits === 0 && node.contributors.length < MAX_NUMBER_OF_CONTRIBUTORS) {
         const openContributionRemaining = this.openForContribution(node);
 
+        let contributors_length = 0;
+        for (const contributor of node.contributors) {
+          contributors_length = contributors_length + contributor.locked_contributions.length;
+        }
+
         minContributionAtomicUnits = openContributionRemaining /
-          (MAX_NUMBER_OF_CONTRIBUTORS - node.contributors.length);
+          (MAX_NUMBER_OF_CONTRIBUTORS - contributors_length);
       }
 
       const minContributionOxen = minContributionAtomicUnits / 1e9;


### PR DESCRIPTION
The number of contributions to a service node is dependant on the number
of locked contributions instead of contributors. The difference being
that a single contributor may make several locked contributions to a
service node which will reduce the number of available slots. To clarify
a single contributor may contribute twice to a service node, using 2
slots rather than one.