### PR TITLE
Sorts the "MY STAKES" service node list alphabetically

### DIFF
--- a/src/components/service_node/service_node_unlock.vue
+++ b/src/components/service_node/service_node_unlock.vue
@@ -72,13 +72,20 @@ export default {
         node.contributors.find(
           c => c.address === this.our_address && c.amount > 0
         );
-      return nodes.filter(getOurContribution).map(n => {
-        const ourContribution = getOurContribution(n);
-        return {
-          ...n,
-          ourContributionAmount: ourContribution.amount
-        };
-      });
+      return nodes
+        .filter(getOurContribution)
+        .sort((a, b) => {
+          if (a.service_node_pubkey < b.service_node_pubkey) return -1;
+          if (a.service_node_pubkey > b.service_node_pubkey) return 1;
+          return 0;
+        })
+        .map(n => {
+          const ourContribution = getOurContribution(n);
+          return {
+            ...n,
+            ourContributionAmount: ourContribution.amount
+          };
+        });
     },
     fetching: state => state.gateway.daemon.service_nodes.fetching
   }),


### PR DESCRIPTION
The list provided to users under service nodes -> my stakes previously
had no sorting, which made it slightly difficult to find the service
node as they would appear in a random order. This simply applys an
alphabetical ordering over the service node pubkeys so that service node
pubkey "0fa72..." will appear before pubkey "7eee3..."